### PR TITLE
A couple fixes for improved version compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Description: A group of functions designed to perform matched-adjusted
 License: Apache License (>= 2)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Imports:
     assertthat (>= 0.2.1),

--- a/R/weights.R
+++ b/R/weights.R
@@ -26,7 +26,7 @@ gradfn <- function(a1, X){
 #' @param method The method used for optimisation - The default is method =
 #'   "BFGS". Refer to \code{\link[stats]{optim}} for options.
 #' @param ... Additional arguments to be passed to optimisation functions such
-#'   as the method for maximum likelihood optimisation. Refer to \code{\link[stats]{optim}}
+#'   as the method for maximum likelihood optimisation. Refer to \code{\link[stats]{optim}} 
 #'   for options.
 #'
 #' @details The premise of MAIC methods is to adjust for between-trial
@@ -244,13 +244,13 @@ hist_wts <- function(data, wt_col="wt", rs_wt_col="wt_rs", bin = 30) {
 
   # create visible local bindings for R CMD check
   value <- `Rescaled weights` <- Weights <- NULL
-
+  
   wt_data1 <- data %>%
     dplyr::select(tidyselect::all_of(c(wt_col, rs_wt_col))) %>% # select only the weights and rescaled weights
     dplyr::rename("Weights" = tidyselect::all_of(wt_col), "Rescaled weights" = tidyselect::all_of(rs_wt_col))  # rename so for plots
-
+  
   # tidyr::gather() # weights and rescaled weights in one column for plotting
-
+  
   wt_data <- dplyr::bind_rows(
     dplyr::transmute(wt_data1, key = "Weights", value = Weights),
     dplyr::transmute(wt_data1, key = "Rescaled weights", value = `Rescaled weights`)


### PR DESCRIPTION
Hi @iain-t-bennett-roche - Thanks for all the updates in MAIC

I'm including just a couple extra changes that help to get the package building on older R versions. Specifically

- I changed calls of `dplyr::all_of` to `tidyselect::all_of`. `dplyr` just reexports the `tidyselect` functions, and only started re-exporting them starting ~2yrs ago with version `1.0.0`. Using the `tidyselect` versions lets you support older dplyr versions.
- I removed the `testthat` version restriction in `DESCRIPTION` since you aren't using any of the recent 3rd edition features. This allows older systems with older versions of `testthat` to run the testsuite without updates.